### PR TITLE
[zsh] uses the https address for cloning zsh repo

### DIFF
--- a/roles/zsh-terminal/tasks/main.yml
+++ b/roles/zsh-terminal/tasks/main.yml
@@ -6,7 +6,7 @@
     - sudoed
 
 - name: Clone oh-my-zsh repo
-  git:  repo=git://github.com/robbyrussell/oh-my-zsh.git
+  git:  repo=https://github.com/robbyrussell/oh-my-zsh.git
         dest=~/.oh-my-zsh
 
 - name:   Copy zshenv


### PR DESCRIPTION
this fixes Issue #1 
